### PR TITLE
Initial Changes

### DIFF
--- a/cards_r01_1.xml
+++ b/cards_r01_1.xml
@@ -21,25 +21,15 @@
 				<Effect Type="IncreaseLevel" Value="1" LevelType="Magic"/>
 			</Target>
 		</Trigger>
-		<Trigger Type="OnThisCardDeath">
-            <Target Zone="BattlegroundColumn" CardType="Unit" Amount="FromTrigger" BattlegroundPositionState="DontCare">
-				<CardFilter ExcludeRaces="Construct"/>
-				<Effect Type="Damage" Value="3"/>
-			</Target>
-		</Trigger>
-		<Description>When [THIS] dies, increase your [MAGIC] level by 1, and deal 3 damage to all non-construct creature of the same row.</Description>
+		<Description>When [THIS] dies, increase your [MAGIC] level by 1.</Description>
 	</Card>
-	<Card  Rarity="Epic" Unique="False" Type="Unit" Name="Cre_Aca_102" DisplayName="Power Blast Titan" Faction="Academy" School="Prime" SubType="Magic|Shooter" Race="Construct|Titan" Cost="4" MightLevel="4" MagicLevel="4" DestinyLevel="0" Attack="3" Retaliate="2" HP="7" ID="1008">
+	<Card  Rarity="Epic" Unique="False" Type="Unit" Name="Cre_Aca_102" DisplayName="Power Blast Titan" Faction="Academy" School="Prime" SubType="Magic|Shooter" Race="Construct|Titan" Cost="4" MightLevel="4" MagicLevel="4" DestinyLevel="0" Attack="3" Retaliate="2" HP="6" ID="1008">
 		<Ability Type="ImmuneToRetaliate"/>
 		<Ability Type="Shockwave" Value="2" />
-		<Trigger Type="OnUnitKillUnit" DamageIncludeFlags="Splash" Side="Friendly" ExecuteOncePerTransaction="True">
+		<Target Zone="Battleground" Amount="All" Side="Friendly">
 			<CardFilter IncludeRaces="Construct"/>
-			<Target Zone="Battleground" Amount="FromTrigger" CardType="Unit" >
-				<Variable Type="UnitAttackCount" FromTrigger="True"/>
-				<Condition Operator="LesserThan" ValueA="Variable" ValueB="2"/>
-				<Effect Type="AdditionalAttack" Value="1"/>
-            </Target>
-		</Trigger>
+			<Effect Type="ModifyAbility" Ability="TitanAttackTwice"/>
+		</Target>
 		<Description>Whenever a friendly construct destory a enemy with blast damage for the first time in a turn, it gains an additional attack.</Description>
 	</Card>
 	<Card  Rarity="Epic" Unique="False" Type="Unit" Name="Cre_Aca_103" DisplayName="Crimson Wizard" Faction="Academy" SubType="Magic|Shooter" Race="Human|Wizard" Cost="4" MightLevel="4" MagicLevel="1" DestinyLevel="0" Attack="3" Retaliate="1" HP="6" ID="1009">
@@ -79,7 +69,7 @@
         </Target>
 		<Description>Adjacent friendly human creatures gain +[1:RET] and Perfect Retaliation.</Description>
 	</Card>
-	<Card Rarity="Epic" Unique="False" Type="Unit" Name="Cre_Hav_102" DisplayName="Blind Justicar" Faction="Haven" SubType="Shooter" Race="Human|Archer" Cost="4" MightLevel="4" MagicLevel="0" DestinyLevel="0" Attack="2" Retaliate="1" HP="7" ID="1012">
+	<Card Rarity="Epic" Unique="False" Type="Unit" Name="Cre_Hav_102" DisplayName="Blind Justicar" Faction="Haven" SubType="Shooter" Race="Human|Archer" Cost="4" MightLevel="4" MagicLevel="0" DestinyLevel="0" Attack="2" Retaliate="1" HP="6" ID="1012">
 		<Ability Type="ImmuneToRetaliate"/>
 		<Trigger Type="OnThisCardDeploy">
 			<Target Zone="Battleground" CardType="Unit" Amount="1" Side="Friendly" />		
@@ -158,12 +148,10 @@
 	</Card>
 	<Card  Rarity="Rare" Unique="False" Type="Unit" Name="Cre_Nec_101" DisplayName="Necromancer Reinforcer" Faction="Necropolis"  SubType="Magic|Shooter" Race="Human|Wizard" Cost="4" MightLevel="3" MagicLevel="1" DestinyLevel="1" Attack="2" Retaliate="0" HP="6" ID="1019">
 		<Ability Type="ImmuneToRetaliate"/>
-		<Trigger Type="OnPreAttackUnit" Side="Friendly">
-			<CardFilter IncludeAbility="Stackable" />
-			<Target Zone="Battleground" Amount="FromTrigger" CardType="Unit" ForceExecute="True">
-				<Effect Type="IncreaseStackSize" Value="1"/>
-            </Target>
-		</Trigger>
+		<Target Zone="Battleground" Amount="All" Side="Friendly">
+			<CardFilter IncludeAbility="Stackable"/>
+			<Effect Type="ModifyAbility" Ability="NecromancerStack"/>
+		</Target>
 		<Description>Whenever a friendly creature with stackable attacks enemy creature, increase its' stack size by 1.</Description>
 	</Card>
 	<Card  Rarity="Epic" Unique="False" Type="Unit" Name="Cre_Nec_102" DisplayName="Namtaru Infector" Faction="Necropolis" SubType="Magic|Melee" Race="Namtaru" Cost="5" MightLevel="4" MagicLevel="2" DestinyLevel="0" Attack="4" Retaliate="3" HP="7" ID="1020" School="Prime">
@@ -176,10 +164,10 @@
 		</Target>
 		<Description>Friendly creatures with Infect gain Infect Blast X, where X is equal to its Infect value.</Description>
 	</Card>
-	<Card  Rarity="Epic" Unique="False" Type="Unit" Name="Cre_Nec_103" DisplayName="Namtaru Contagion" Faction="Necropolis" SubType="Magic|Shooter" Race="Namtaru" Cost="5" MightLevel="4" MagicLevel="2" DestinyLevel="0" Attack="3" Retaliate="2" HP="6" ID="1021" School="Prime">
+	<Card  Rarity="Epic" Unique="False" Type="Unit" Name="Cre_Nec_103" DisplayName="Ichor Weaver" Faction="Necropolis" SubType="Magic|Shooter" Race="Namtaru" Cost="5" MightLevel="4" MagicLevel="2" DestinyLevel="0" Attack="3" Retaliate="2" HP="6" ID="1021" School="Prime">
 		<Ability Type="ImmuneToRetaliate"/>
 		<Ability Type="Infect" Value="1"/>	
-		<Variable Type="LastAliveCounterCount" CounterType="Poison" FromTrigger="True"/>		
+		<Variable Type="LastAliveCounterCount" CounterType="Poison" FromTrigger="True"/>	
 		<Trigger Type="OnUnitDeath">
 			<Target Zone="Battleground" Amount="Variable" CardType="Unit" Random="True" AllowDuplicate="True">
 				<Effect Type="AddCounter" CounterType="Poison" Value="1"/>
@@ -212,10 +200,16 @@
 		<Description>Whenever a spy deal damage to enemy hero, next Sanctuary fortune cost 1 less to play.</Description>
 	</Card>
 	<Card  Rarity="Epic" Unique="False" Type="Unit" Name="Cre_San_102" DisplayName="Shinobi Whisperer" Faction="Sanctuary" SubType="Shooter" Race="Naga|Spy" Cost="5" MightLevel="4" MagicLevel="0" DestinyLevel="2" Attack="3" Retaliate="3" HP="7" ID="1024">
-		<Ability Type="ImmuneToRetaliate"/>				
-		<Trigger Type="OnUnitKillUnit" DamageIncludeFlags="Attack" Side="Friendly">	
-			<CardFilter IncludeRaces="Spy" />
-			<Target Zone="Battleground" CardType="Unit" Amount="1" Side="Enemy" Cancelable="False">
+		<Ability Type="ImmuneToRetaliate"/>	
+		<Variable Type="TargetCount">
+            <Target Zone="Battleground" CardType="Unit" Amount="All" Side="Friendly" />
+        </Variable>
+        <Variable2 Type="TargetCount">
+            <Target Zone="Battleground" CardType="Unit" Amount="All" Side="Enemy" />
+        </Variable2>
+		<Trigger Type="OnTurnBegin" Side="Friendly" ExecuteOncePerTurn="True">	
+		<Target Zone="Battleground" CardType="Unit" Amount="1" Side="Enemy" Cancelable="False">
+				<Condition Operator="LesserThan" ValueA="Variable" ValueB="Variable2" />
 				<Effect Type="MoveCardTo" Destination="Hand" />
 			</Target>
 		</Trigger>

--- a/cards_s01_1.xml
+++ b/cards_s01_1.xml
@@ -45,7 +45,7 @@
         <Ability Type="ImmuneToRetaliate" />
         <Ability Type="AttackAnywhere" />
     </Card>
-    <Card  Rarity="Rare" Type="Unit" Name="Cre_Inf_022" DisplayName="Hellfire Juggernaut" Faction="Inferno" School="Fire" SubType="Magic|Melee" Race="Demon|Juggernaut" Cost="5" MightLevel="5" MagicLevel="1" Attack="7" Retaliate="3" HP="3" ID="266">
+    <Card  Rarity="Rare" Type="Unit" Name="Cre_Inf_022" DisplayName="Hellfire Juggernaut" Faction="Inferno" School="Fire" SubType="Magic|Melee" Race="Demon|Juggernaut" Cost="4" MightLevel="5" MagicLevel="1" Attack="7" Retaliate="3" HP="3" ID="266">
         <Ability Type="FireBurst" Value="4" />
 		<Ability Type="Tremple" />
 		<Description>When [THIS] attacks and destroys a creature, overkill damage is redirected to enemy Hero.</Description>
@@ -66,7 +66,7 @@
     <Card Rarity="Common" Type="Unit" Name="Cre_Nec_020" DisplayName="Moonsilk Skeleton" Faction="Necropolis" SubType="Melee" Race="Skeleton" Cost="2" MightLevel="2" Attack="2" Retaliate="1" HP="3" ID="268">
         <Ability Type="Crippling" Value="1" />
     </Card>
-    <Card Rarity="Uncommon" Type="Unit" Name="Cre_Nec_021" DisplayName="Moonsilk Spinner" Faction="Necropolis" SubType="Melee|Shooter" Race="Spider" Cost="4" MightLevel="4" Attack="2" Retaliate="2" HP="5" ID="269">
+    <Card Rarity="Uncommon" Type="Unit" Name="Cre_Nec_021" DisplayName="Moonsilk Spinner" Faction="Necropolis" SubType="Melee|Shooter" Race="Spider" Cost="4" MightLevel="3" Attack="2" Retaliate="2" HP="6" ID="269">
         <Ability Type="Crippling" Value="2" />
     </Card>
     <Card Rarity="Epic" Type="Unit" Name="Cre_Nec_023" DisplayName="Vampire Assassin" Faction="Necropolis" SubType="Melee" Race="Vampire|Assassin" Cost="4" MightLevel="3" Attack="1" Retaliate="2" HP="4" ID="270">
@@ -77,7 +77,7 @@
         </Trigger>
         <Description>When Vampire Assassin deals combat damage to a creature, destroy that creature.</Description>
     </Card>
-    <Card Rarity="Rare" Type="Unit" Name="Cre_Nec_022" DisplayName="Fate Sealer" Faction="Necropolis" School="Dark" SubType="Magic|Flyer" Race="Namtaru" Cost="6" MightLevel="3" MagicLevel="1" DestinyLevel="3" Attack="2" Retaliate="2" HP="5" ID="271">
+    <Card Rarity="Rare" Type="Unit" Name="Cre_Nec_022" DisplayName="Fate Sealer" Faction="Necropolis" School="Dark" SubType="Magic|Flyer" Race="Namtaru" Cost="5" MightLevel="3" MagicLevel="1" DestinyLevel="3" Attack="2" Retaliate="2" HP="5" ID="271">
         <Ability Type="Incorporeal" />
         <Ability Type="LifeDrain" Value="2" />
         <Trigger Type="OnUnitDeath" Side="Friendly">
@@ -186,7 +186,7 @@
     <!-- Creatures - Stronghold -->
     <!--...............................................................................-->
     <Card Rarity="Common" Type="Unit" Name="Cre_Str_020" DisplayName="Blackskull Warchanter" Faction="Stronghold" SubType="Melee" Race="Orc" Cost="1" MightLevel="1" Attack="0" Retaliate="0" HP="2" ID="276">
-        <Trigger Type="OnTurnEnd" Side="Friendly">
+        <Trigger Type="OnTurnBegin" Side="Friendly">
             <Target Zone="Battleground" CardType="Unit" Amount="All" Side="Friendly">
                 <CardFilter IncludeAbility="Enrage" />
                 <Effect Type="AddCounter" CounterType="Enrage" Value="1" />

--- a/cards_s02_1.xml
+++ b/cards_s02_1.xml
@@ -20,10 +20,10 @@
     <Card Rarity="Uncommon" Type="Unit" Name="Cre_Hav_042" DisplayName="Griffin Mounted Spearman" Faction="Haven" SubType="Melee" Race="Human|Knight" Cost="4" MightLevel="4" Attack="3" Retaliate="2" HP="6" ID="347">
         <Ability Type="Swift" />
     </Card>
-    <Card Rarity="Uncommon" Type="Unit" Name="Cre_Hav_043" DisplayName="Griffin Knight" Faction="Haven" SubType="Flyer" Race="Human|Knight" Cost="3" MightLevel="3" Attack="1" Retaliate="2" HP="5" ID="348">
+    <Card Rarity="Uncommon" Type="Unit" Name="Cre_Hav_043" DisplayName="Griffin Knight" Faction="Haven" SubType="Flyer" Race="Human|Knight" Cost="3" MightLevel="3" Attack="1" Retaliate="2" HP="6" ID="348">
         <Ability Type="FlyerGuard" Value="2" />
     </Card>
-    <Card Rarity="Rare" Type="Unit" Name="Cre_Hav_044" DisplayName="Immaculate Glory" Faction="Haven" School="Light" SubType="Magic|Flyer" Race="Spirit" Cost="5" MightLevel="4" MagicLevel="2" Attack="3" Retaliate="3" HP="6" ID="349">
+    <Card Rarity="Rare" Type="Unit" Name="Cre_Hav_044" DisplayName="Immaculate Glory" Faction="Haven" School="Light" SubType="Magic|Flyer" Race="Spirit" Cost="5" MightLevel="4" MagicLevel="2" Attack="3" Retaliate="3" HP="7" ID="349">
         <Ability Type="DarkWard" />
         <Target Zone="Battleground" CardType="Unit" Amount="Self">
             <Effect Type="PlayEffect" PlayEffectType="CannotPutCounter" Duration="Static" />
@@ -47,7 +47,7 @@
         <Ability Type="CannotAttack" />
         <Ability Type="FireBurst" Value="4" />
     </Card>
-    <Card Rarity="Common" Type="Unit" Name="Cre_Inf_041" DisplayName="Hellfire Slave" Faction="Inferno" School="Fire" SubType="Shooter" Race="Demon|Juggernaut" Cost="4" MightLevel="4" Attack="4" Retaliate="4" HP="4" ID="352">
+    <Card Rarity="Common" Type="Unit" Name="Cre_Inf_041" DisplayName="Hellfire Slave" Faction="Inferno" School="Fire" SubType="Shooter" Race="Demon|Juggernaut" Cost="4" MightLevel="3" Attack="4" Retaliate="4" HP="4" ID="352">
         <Ability Type="ImmuneToRetaliate" />
     </Card>
     <Card Rarity="Uncommon" Type="Unit" Name="Cre_Inf_042" DisplayName="Chaos Lacerator" Faction="Inferno" School="Fire" SubType="Magic|Melee" Race="Demon|Tormentor" Cost="2" MightLevel="2" MagicLevel="1" DestinyLevel="1" Attack="2" Retaliate="0" HP="3" ID="353">
@@ -108,16 +108,16 @@ When Chaos Seer leaves the battleground during opponent's turn, they discard a c
         <Ability Type="CannotAttack" />
         <Ability Type="Regenerate" Value="1" />
     </Card>
-    <Card Rarity="Common" Type="Unit" Name="Cre_Nec_041" DisplayName="Skeleton Archer" Faction="Necropolis" SubType="Shooter" Race="Skeleton" Cost="3" MightLevel="3" Attack="2" Retaliate="2" HP="5" ID="358">
+    <Card Rarity="Common" Type="Unit" Name="Cre_Nec_041" DisplayName="Skeleton Archer" Faction="Necropolis" SubType="Shooter" Race="Skeleton" Cost="3" MightLevel="2" Attack="2" Retaliate="2" HP="5" ID="358">
         <Ability Type="ImmuneToRetaliate" />
     </Card>
     <Card Rarity="Common" Type="Unit" Name="Cre_Nec_042" DisplayName="Untamed Wraith" Faction="Necropolis" School="Prime" SubType="Magic|Flyer" Race="Ghost" Cost="3" MightLevel="3" MagicLevel="1" Attack="2" Retaliate="2" HP="4" ID="360">
         <Ability Type="Incorporeal" />
     </Card>
-    <Card Rarity="Rare" Type="Unit" Name="Cre_Nec_043" DisplayName="Living Nightmare" Faction="Necropolis" School="Dark" SubType="Melee" Race="Zombie|Hound" Cost="5" MightLevel="4" Attack="3" Retaliate="3" HP="6" ID="359">
+    <Card Rarity="Rare" Type="Unit" Name="Cre_Nec_043" DisplayName="Living Nightmare" Faction="Necropolis" School="Dark" SubType="Melee" Race="Zombie|Hound" Cost="4" MightLevel="5" Attack="3" Retaliate="3" HP="6" ID="359">
         <Ability Type="Fear" Value="3" />
     </Card>
-    <Card Rarity="Uncommon" Type="Unit" Name="Cre_Nec_044" DisplayName="Soul-Consuming Lich" Faction="Necropolis" School="Dark" SubType="Melee" Race="Lich" Cost="4" MightLevel="4" Attack="2" Retaliate="1" HP="7" ID="361">
+    <Card Rarity="Uncommon" Type="Unit" Name="Cre_Nec_044" DisplayName="Soul-Consuming Lich" Faction="Necropolis" School="Dark" SubType="Melee" Race="Lich" Cost="4" MightLevel="4" Attack="2" Retaliate="1" HP="8" ID="361">
         <Trigger Type="OnUnitDeath" Side="Any">
             <Target Zone="Battleground" CardType="Unit" Amount="Self">
                 <Effect Type="Heal" Value="2" />
@@ -142,7 +142,7 @@ When Chaos Seer leaves the battleground during opponent's turn, they discard a c
     <Card Rarity="Common" Type="Unit" Name="Cre_San_040" DisplayName="Waterfall Guardians" Faction="Sanctuary" School="Water" SubType="Melee" Race="Spirit" Cost="2" MightLevel="1" Attack="0" Retaliate="2" HP="5" ID="363">
         <Ability Type="Hypnotize" />
     </Card>
-    <Card Rarity="Common" Type="Unit" Name="Cre_San_041" DisplayName="Naga Yokujin" Faction="Sanctuary" SubType="Shooter" Race="Naga|Archer" Cost="3" MightLevel="3" Attack="2" Retaliate="2" HP="5" ID="364">
+    <Card Rarity="Common" Type="Unit" Name="Cre_San_041" DisplayName="Naga Yokujin" Faction="Sanctuary" SubType="Shooter" Race="Naga|Archer" Cost="3" MightLevel="3" Attack="2" Retaliate="1" HP="6" ID="364">
         <Ability Type="ImmuneToRetaliate" />
     </Card>
     <Card Rarity="Common" Type="Unit" Name="Cre_San_042" DisplayName="Okane no Okane" Faction="Sanctuary" School="Prime" SubType="Shooter" Race="Eel" Cost="3" MightLevel="2" DestinyLevel="1" Attack="2" Retaliate="1" HP="4" ID="365">
@@ -178,7 +178,7 @@ When Chaos Seer leaves the battleground during opponent's turn, they discard a c
     <!--...............................................................................-->
     <!-- Creatures - Stronghold -->
     <!--...............................................................................-->
-    <Card Rarity="Common" Type="Unit" Name="Cre_Str_040" DisplayName="Bramble Beast" Faction="Stronghold" School="Earth" SubType="Melee" Race="Plant" Cost="2" MightLevel="1" Attack="0" Retaliate="2" HP="5" ID="369">
+    <Card Rarity="Common" Type="Unit" Name="Cre_Str_040" DisplayName="Bramble Beast" Faction="Stronghold" School="Earth" SubType="Melee" Race="Plant" Cost="2" MightLevel="1" Attack="0" Retaliate="2" HP="4" ID="369">
         <Ability Type="Armor" Value="1" />
         <Ability Type="SpellResist" />
     </Card>
@@ -187,12 +187,12 @@ When Chaos Seer leaves the battleground during opponent's turn, they discard a c
         <Ability Type="ImmuneToRetaliate" />
         <Ability Type="Swift" />
     </Card>
-    <Card Rarity="Uncommon" Type="Unit" Name="Cre_Str_043" DisplayName="Blackskull Shredder" Faction="Stronghold" School="Air" SubType="Melee" Race="Orc|Warrior" Cost="4" MightLevel="4" Attack="2" Retaliate="0" HP="4" ID="372">
+    <Card Rarity="Uncommon" Type="Unit" Name="Cre_Str_043" DisplayName="Blackskull Shredder" Faction="Stronghold" School="Air" SubType="Melee" Race="Orc|Warrior" Cost="4" MightLevel="4" Attack="2" Retaliate="0" HP="3" ID="372">
         <Ability Type="QuickAttack" />
         <Ability Type="Swift" />
     </Card>
     <Card Rarity="Rare" Type="Unit" Name="Cre_Str_044" DisplayName="Bloodfrenzied Wyvern" Faction="Stronghold" SubType="Flyer" Race="Wyvern" Cost="5" MightLevel="5" Attack="3" Retaliate="3" HP="8" ID="373">
-        <Ability Type="BloodThirst" Value="1" />
+		<Ability Type="Bloodthirst" Value="1"/>
     </Card>
     <Card Rarity="Epic" Type="Unit" Name="Cre_Str_045" DisplayName="Blackskull Cyclops" Faction="Stronghold" SubType="Melee" Race="Cyclops" Cost="6" MightLevel="6" Attack="3" Retaliate="0" HP="6" ID="374">
         <Ability Type="DoubleAttack" />
@@ -232,6 +232,7 @@ When Chaos Seer leaves the battleground during opponent's turn, they discard a c
     <Card Rarity="Rare" Type="Unit" Name="Cre_Neu_044" DisplayName="Greater Earth Elemental" Faction="Neutral" School="Earth" SubType="Magic|Melee" Race="Spirit" Cost="6" MightLevel="5" MagicLevel="2" Attack="3" Retaliate="4" HP="9" ID="379">
         <Ability Type="EarthHeal" />
         <Ability Type="Towering" />
+        <Ability Type="Anchored" />
     </Card>
     <Card Rarity="Rare" Type="Unit" Name="Cre_Neu_045" DisplayName="Void Keeper" Faction="Neutral" School="Prime" SubType="Magic|Shooter" Race="Human|Wizard" Cost="4" MightLevel="3" MagicLevel="1" DestinyLevel="2" Attack="2" Retaliate="1" HP="5" ID="380">
         <Ability Type="ImmuneToRetaliate" />
@@ -258,11 +259,11 @@ When Chaos Seer leaves the battleground during opponent's turn, they discard a c
     <Card Rarity="Uncommon" Type="Unit" Name="Cre_Inf_046" DisplayName="Lurker in the Dark" Faction="Inferno" School="Dark" SubType="Melee" Race="Demon|Breeder" Cost="2" MightLevel="3" Attack="2" Retaliate="0" HP="4" ID="383">
         <Ability Type="Fear" Value="2" />
     </Card>
-    <Card Rarity="Common" Type="Unit" Name="Cre_Inf_047" DisplayName="Ur-Khrag Enforcer" Faction="Inferno" SubType="Melee" Race="Demon|Juggernaut" Cost="5" MightLevel="5" Attack="4" Retaliate="5" HP="7" ID="384">
+    <Card Rarity="Common" Type="Unit" Name="Cre_Inf_047" DisplayName="Ur-Khrag Enforcer" Faction="Inferno" SubType="Melee" Race="Demon|Juggernaut" Cost="5" MightLevel="5" Attack="5" Retaliate="5" HP="7" ID="384">
         <Ability Type="SweepAttack" />
         <Ability Type="Berserk" />
     </Card>
-    <Card  Rarity="Uncommon" Type="Unit" Name="Cre_Nec_046" DisplayName="Dark Wood Hermit" Faction="Necropolis" School="Earth" SubType="Magic|Shooter" Race="Lich" Cost="4" MightLevel="4" MagicLevel="1" Attack="2" Retaliate="1" HP="6" ID="385">
+    <Card  Rarity="Uncommon" Type="Unit" Name="Cre_Nec_046" DisplayName="Dark Wood Hermit" Faction="Necropolis" School="Earth" SubType="Magic|Shooter" Race="Lich" Cost="4" MightLevel="3" MagicLevel="1" Attack="2" Retaliate="1" HP="6" ID="385">
         <Ability Type="ImmuneToRetaliate" />
 		<Ability Type="Infect" Value="1"/>
         <Target Zone="Battleground" CardType="Unit" Amount="AllOther" Side="Friendly">
@@ -294,7 +295,7 @@ When Chaos Seer leaves the battleground during opponent's turn, they discard a c
     <Card Rarity="Uncommon" Type="Unit" Name="Cre_San_047" DisplayName="Venerable Kappa" Faction="Sanctuary" SubType="Melee" Race="Spirit" Cost="4" MightLevel="4" DestinyLevel="1" Attack="3" Retaliate="3" HP="6" ID="388">
         <Ability Type="FortuneWard" />
     </Card>
-    <Card Rarity="Uncommon" Type="Unit" Name="Cre_Str_047" DisplayName="Blackskull Spellsmasher" Faction="Stronghold" SubType="Melee" Race="Orc|Warrior" Cost="4" MightLevel="4" Attack="2" Retaliate="2" HP="6" ID="389">
+    <Card Rarity="Uncommon" Type="Unit" Name="Cre_Str_047" DisplayName="Blackskull Spellsmasher" Faction="Stronghold" SubType="Melee" Race="Orc|Warrior" Cost="4" MightLevel="4" Attack="2" Retaliate="2" HP="7" ID="389">
         <Trigger Type="OnThisPreAttack">
             <Target Zone="Battleground" CardType="Spell" Side="Any" Amount="1" Cancelable="False">
                 <Effect Type="Kill" />

--- a/cards_s02_3.xml
+++ b/cards_s02_3.xml
@@ -54,9 +54,13 @@ At the beginning of enchanted creature's controller's turn, deal 1 damage to the
         <Description>Until your next turn:
 Creatures with no adjacent friendly creature gain Cannot Attack.</Description>
     </Card>
-    <Card Rarity="Epic" Unique="True" Type="Spell" Name="Spe_Dar_042" DisplayName="The Silent Death" School="Dark" Cost="4" MagicLevel="4" ID="423">
+    <Card NotLocalized="True" Rarity="Epic" Unique="True" Type="Spell" Name="Spe_Dar_042" DisplayName="The Silent Death" School="Dark" Cost="5" MagicLevel="4" ID="423">
         <Ongoing Duration="Permanent" />
-        <Target Zone="Battleground" CardType="Unit" Amount="1" />
+      <Target Zone="Battleground" CardType="Unit" Amount="1">
+        <Effect Type="ModifyAbility" Ability="CannotAttack" />
+        <Effect Type="ModifyAbility" Ability="Phased" />
+        <Effect Type="ModifyAbility" Ability="Immobilized" />
+      </Target>
         <Trigger Type="OnTurnBegin" Side="Friendly">
             <Target Zone="Battleground" Amount="Self">
                 <Effect Type="MoveCardTo" Destination="Hand" />
@@ -67,8 +71,9 @@ Creatures with no adjacent friendly creature gain Cannot Attack.</Description>
                 </Subgroup>
             </Target>
         </Trigger>
-        <Description>Enchant Creature. Permanent:
-At the beginning of your turn, destroy enchanted creature and return The Silent Death to its owner's hand.</Description>
+        <Description>
+          Enchant Creature. Permanent:
+          Enchanted creature is Immobilized and gains Cannot Attack and Phased. At the beginning of your turn, destroy enchanted creature and return The Silent Death to its owner's hand.</Description>
     </Card>
     <!--....................................................................-->
     <!-- Spells - Earth -->
@@ -81,8 +86,9 @@ At the beginning of your turn, destroy enchanted creature and return The Silent 
         <Description>Enchant creature. Permanent:
 Enchanted creature gains Anchored.</Description>
     </Card>
-    <Card Rarity="Uncommon" Type="Spell" Name="Spe_Ear_041" DisplayName="Sylanna's Embrace" School="Earth" Cost="2" MagicLevel="3" ID="425">
+    <Card Rarity="Uncommon" Type="Spell" Name="Spe_Ear_041" DisplayName="Sylanna's Embrace" School="Earth" Cost="2" MagicLevel="2" ID="425">
         <Ongoing Duration="Permanent" />
+        <Ability Type="Endurable"/>
         <Target Zone="Battleground" CardType="Unit" Amount="1" Side="Any">
             <Effect Type="ModifyMaxHp" Value="2" />
             <Effect Type="ModifyAbility" Ability="Regenerate" Value="1" />
@@ -117,10 +123,10 @@ Damage dealt to friendly melee creatures in the front line is halved, rounded do
         <Description>Enchant creature. Permanent:
 Enchanted creature gains +[1:ATK] and Berserk.</Description>
     </Card>
-    <Card Rarity="Epic" Unique="True" Type="Spell" Name="Spe_Fir_042" DisplayName="The Forbidden Flame" School="Fire" Cost="4" MagicLevel="3" ID="429">
+    <Card Rarity="Epic" Unique="True" Type="Spell" Name="Spe_Fir_042" DisplayName="The Forbidden Flame" School="Fire" Cost="5" MagicLevel="3" ID="429">
         <Target Zone="Battleground" Side="Any" Amount="All" CardType="Unit">
             <Variable Type="Level" LevelType="Magic" ValueModifier="2.0x" Side="Friendly" />
-            <Effect Type="Damage" Value="Variable" />
+            <Effect Type="Damage" Value="Variable" DamageFlags="Spell|Fire|Magic|Enforced" />
         </Target>
         <Description>Deal damage to all creatures equal to double your [MAGIC] level.</Description>
     </Card>
@@ -157,7 +163,7 @@ At the beginning of your turn, take a non-unique creature card at random from yo
     <!--....................................................................-->
     <!-- Spells - Prime -->
     <!--....................................................................-->
-    <Card Rarity="Common" Type="Spell" Name="Spe_Pri_040" DisplayName="Minor Recall" School="Prime" Cost="3" MagicLevel="3" ID="433">
+    <Card Rarity="Common" Type="Spell" Name="Spe_Pri_040" DisplayName="Minor Recall" School="Prime" Cost="1" MagicLevel="3" ID="433">
         <Target Zone="Battleground" Amount="1">
             <CardFilter IncludeCardType="Fortune|Spell" />
             <Effect Type="MoveCardTo" Destination="Hand" />
@@ -171,16 +177,20 @@ At the beginning of your turn, take a non-unique creature card at random from yo
         </Target>
         <Description>Look at opponent's hand and choose a non-unique fortune card from it. You can play this fortune for free. If you don't, put that card into opponent's graveyard.</Description>
     </Card>
-    <Card Rarity="Epic" Unique="True" Type="Spell" Name="Spe_Pri_042" DisplayName="The Gate to Nowhere" School="Prime" Cost="3" MagicLevel="3" ID="435">
+    <Card NotLocalized="True" Rarity="Epic" Unique="True" Type="Spell" Name="Spe_Pri_042" DisplayName="The Gate to Nowhere" School="Prime" Cost="3" MagicLevel="3" ID="435">
         <Ongoing Duration="Permanent" />
         <Target Zone="BattlegroundColumn" Amount="1" />
-        <Trigger Type="OnPostAttackThisRow" Side="Enemy">
-            <Target Zone="None" Amount="FromTrigger">
-                <Effect Type="Banish" />
+        <Trigger Type="OnTurnBegin" Side="Any">
+            <Target Zone="Battleground" CardType="Unit" Amount="1" Cancelable="True">
+              <CardFilter IncludeColumn="True" Value="Variable2">
+                <Variable2 Type="CardColumn" />
+              </CardFilter>
+              <Effect Type="Banish" />
             </Target>
         </Trigger>
-        <Description>Enchant Row. Permanent:
-After an enemy creature on enchanted row attacks, banish it.</Description>
+        <Description>
+          Enchant Row. Permanent:
+          At the beginning of the his turn, each player banish target creature on this row if he want.</Description>
     </Card>
     <!--....................................................................-->
     <!-- Spells - Water -->

--- a/cards_tl.xml
+++ b/cards_tl.xml
@@ -49,6 +49,24 @@
             </Target>
         </Trigger>
     </TemplateEffect>
+	
+	<TemplateEffect Name="TitanAttackTwice">
+        <Trigger Type="OnThisKillUnit" DamageIncludeFlags="Splash" Side="Friendly" ExecuteOncePerTurn="True">
+            <Target Zone="Battleground" Amount="Self">
+                <Variable Type="UnitAttackCount"/>
+                <Condition Operator="LesserThan" ValueA="Variable" ValueB="2"/>
+                <Effect Type="AdditionalAttack" Value="1" OwnerAbility="TitanAttackTwice"/>
+            </Target>
+        </Trigger>
+    </TemplateEffect>
+	
+		<TemplateEffect Name="NecromancerStack">
+        <Trigger Type="OnThisPreAttackUnit" Side="Friendly" ExecuteOncePerTurn="True">
+            <Target Zone="Battleground" Amount="Self">
+                <Effect Type="IncreaseStackSize" Value="1" OwnerAbility="NecromancerStack"/>
+            </Target>
+        </Trigger>
+    </TemplateEffect>
 
     <TemplateEffect Name="Berserk">
         <Trigger Type="OnActionPhaseBegin" Side="Friendly">


### PR DESCRIPTION
Power Blast Titan: Ability does not stack
Necromancer Reinforcer: Ability does not stack
Shinobi Whisperer: rework "at the start of your turn, if your enemy controls more creatures, return target enemy creature to their owners hand" - oen use per Whisperer.
 Forbidden Flame: + Damage cannot be prevented or reduced
Bramble Beast: 4 HP
Blackskull Warchanter: Triggers at the start of turn instead.